### PR TITLE
Fixing wrong typing for ClusterWS.subscribe() method.

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -10,7 +10,7 @@ export class ClusterWS {
     send(event: string, data: any, type?: string): void;
     disconnect(code?: number, msg?: any): void;
     getState(): number;
-    subscribe(channel: string): void;
+    subscribe(channel: string): Channel;
     getChannelByName(channelName: string): Channel;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export class ClusterWS {
         return this.websocket.readyState
     }
 
-    public subscribe(channel: string): void {
+    public subscribe(channel: string): Channel {
         return this.channels[channel] ? this.channels[channel] : this.channels[channel] = new Channel(this, channel)
     }
 


### PR DESCRIPTION
Hi,

I recently faced an issue while creating a subscription with ClusterWS.subscribe() method. I'm using Typescript and the current typing of this method is "void" that makes the Pub/Sub example from README.md impossible to compile (TS2339: Property 'watch' does not exist on type 'void').

Thank you for your work, I appreciate working with ClusterWS ;)